### PR TITLE
0137 event tag component

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "nuxt.isNuxtApp": false
-}

--- a/components/EventTag.vue
+++ b/components/EventTag.vue
@@ -30,7 +30,7 @@ function getTagInfo(type: EventType): string {
 }
 const tagStyle = computed(() => {
   return {
-background: '${getTagColor(props.eventType)}'
+    background: '${getTagColor(props.eventType)}'
   }
 }
 </script>


### PR DESCRIPTION
- ＜style＞内で”function getTagColor”を呼び出す文法がよく分からなかった
- ３種のイベントタイプに応じて色と言葉を返す
- 修飾は、背景色をつけたのみ