### PR TITLE
「企画一覧に戻る」ボタンの作成、idページ下の空白を削除

### DIFF
--- a/components/BackToEvent.vue
+++ b/components/BackToEvent.vue
@@ -1,0 +1,49 @@
+<script setup lang="ts"></script>
+
+<template>
+  <div class="back-to-home">
+    <NuxtLink to="/" class="back-to-home-button-border">
+      <div class="back-to-home-button">
+        <div class="back-to-home-button-text">
+          <p>企画一覧に戻る</p>
+        </div>
+      </div>
+    </NuxtLink>
+  </div>
+</template>
+
+<style scoped lang="scss">
+.back-to-home {
+  margin: 2em 0;
+  transition: 0.3s;
+  width: fit-content;
+
+  &:active {
+    padding-top: 0.3em;
+  }
+
+  .back-to-home-button-border {
+    text-decoration: none;
+
+    .back-to-home-button {
+      border-radius: 2em;
+      border: solid 1px var(--thick-font-color);
+
+      .back-to-home-button-text {
+        color: var(--thick-font-color);
+        padding: 1em 0;
+        width: min(10em, 40svw);
+        text-align: center;
+      }
+    }
+  }
+}
+
+.back-to-home-button:hover {
+  background-color: var(--thick-font-color);
+
+  .back-to-home-button-text:hover {
+    color: #fff;
+  }
+}
+</style>

--- a/pages/event/[id].vue
+++ b/pages/event/[id].vue
@@ -9,6 +9,7 @@ import "swiper/css/pagination";
 // import required modules
 import { Autoplay, Pagination } from "swiper/modules";
 import { placeToString } from "~/model/area";
+import BackToEvent from "~/components/BackToEvent.vue";
 
 const route = useRoute();
 const id = route.params.id; // idが数値でない場合はトップページにリダイレクト
@@ -136,7 +137,7 @@ for (let i = 1; i <= event?.activity_images; i++) {
           {{ event?.website }}
         </a>
       </div>
-      <BackToHome />
+      <BackToEvent />
     </div>
   </div>
 </template>
@@ -149,7 +150,6 @@ for (let i = 1; i <= event?.activity_images; i++) {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-bottom: 10em;
 }
 
 .page-content {


### PR DESCRIPTION
idページ下方の修正
ホームに戻る(BackToHome)→企画一覧に戻る(BackToEvent)
page-rootのpadding-bottom 10em→0