### PR TITLE
Release workflowのTriggerを変更

### DIFF
--- a/.github/workflows/deploy-cloudrun-release.yaml
+++ b/.github/workflows/deploy-cloudrun-release.yaml
@@ -1,8 +1,8 @@
 name: Deploy to Cloud Run (Release)
 on:
-  push:
-    branches:
-      - release
+  release:
+    types:
+      - released
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -12,10 +12,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-
       - name: Login to Google Cloud
         id: auth
         uses: google-github-actions/auth@v2
@@ -23,12 +21,10 @@ jobs:
           token_format: access_token
           workload_identity_provider: 'projects/292061085119/locations/global/workloadIdentityPools/github-pool/providers/provider-github'
           service_account: 'gh-actions@ynufes-hp-cloudrun.iam.gserviceaccount.com'
-
       - name: Set up Cloud SDK
         uses: 'google-github-actions/setup-gcloud@v2'
         with:
           version: '>= 363.0.0'
-
       - name: Authorize Docker
         id: docker-auth
         uses: docker/login-action@v3
@@ -36,17 +32,14 @@ jobs:
           username: 'oauth2accesstoken'
           password: ${{ steps.auth.outputs.access_token }}
           registry: asia-northeast1-docker.pkg.dev
-
       - name: Configure .env
         run: |
           echo "IS_PRODUCTION=true" >> .env
           echo "CONTEST_DATA_URL=${{ secrets.CONTEST_DATA_URL }}" >> .env
-
       - name: Download events.json from external URL
         run: |
           curl "${{ secrets.EVENTS_COMPLETE_URL }}" -o ./assets/data/events-detail.json
           curl "${{ secrets.EVENTS_SUMMARY_URL }}" -o ./assets/data/events.json
-
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -54,17 +47,14 @@ jobs:
           tags: asia-northeast1-docker.pkg.dev/ynufes-hp-cloudrun/release/tokiwa23:latest
           context: .
           file: ./cloudrun/Dockerfile
-
       - name: Download Cloud Run Service YAML
         run: |
           gcloud run services describe hp-main --format yaml --region asia-northeast1 > ./cloudrun/service-hp-main.yaml
-
       # replace github_sha field to latest commit sha. Changing spec.template is required to deploy new revision.
       # reference: https://cloud.google.com/run/docs/deploying?hl=ja#revision -- check yaml tab.
       - name: Change some property of service-hp-main.yaml
         run: |
           sed -i "s/github_sha: .*/github_sha: ${{ github.sha }}/g" ./cloudrun/service-hp-main.yaml
-
       - name: Deploy to Cloud Run
         id: deploy
         uses: google-github-actions/deploy-cloudrun@v2


### PR DESCRIPTION
- dependabotによる依存性の更新が入ったため、更新後のバージョンを反映しようとした。
- Tokiwa23ではreleaseのworkflowとして、 `release` ブランチにpushされるタイミングに設定されていた
- `tokiwa24` と同じく `release` されたタイミングで反映されるようにしたい

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Deployment process now triggers on official GitHub release events, enhancing reliability and predictability.
- **Improvements**
	- Streamlined deployment strategy focusing on versioned releases instead of branch-based deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->